### PR TITLE
fix: restore build health for scheduler workers and legacy cmd

### DIFF
--- a/cmd/annual_billing.go
+++ b/cmd/annual_billing.go
@@ -115,7 +115,7 @@ func (ab *AnnualBillingJob) AnnualBilling() error {
 			InvoiceDesc: invoiceDesc,
 		}
 
-		err = ab.paymentRepository.ChargeCustomer(billingParams, user, workspace, &invoice)
+		_, err = ab.paymentRepository.ChargeCustomer(billingParams, user, workspace, &invoice)
 		if err != nil {
 			helpers.Log(logrus.ErrorLevel, "error charging user..\r\n")
 			helpers.Log(logrus.ErrorLevel, err.Error())

--- a/cmd/annual_billing_test.go
+++ b/cmd/annual_billing_test.go
@@ -10,6 +10,7 @@ import (
 	helpers "github.com/Lineblocs/go-helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	billing "lineblocs.com/scheduler/handlers/billing"
 	"lineblocs.com/scheduler/mocks"
 )
 
@@ -19,7 +20,7 @@ func testAnnualServicePlans() []helpers.ServicePlan {
 			MinutesPerMonth:          200.0,
 			BaseCosts:                24.99,
 			ImIntegrations:           true,
-			Name:                     "starter",
+			KeyName:                  "starter",
 			ProductivityIntegrations: true,
 			RecordingSpace:           1024.0,
 		},
@@ -183,7 +184,7 @@ func TestAnnualBilling(t *testing.T) {
 		mockWorkspace.EXPECT().GetWorkspaceFromDB(mock.Anything).Return(testWorkspace, nil)
 		mockWorkspace.EXPECT().GetUserFromDB(mock.Anything).Return(testUser, nil)
 
-		mockPayment.EXPECT().ChargeCustomer(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		mockPayment.EXPECT().ChargeCustomer(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&billing.ChargeResult{}, nil)
 		mockPayment.EXPECT().GetServicePlans().Return(testAnnualServicePlans(), nil)
 
 		db, mockSql, err := sqlmock.New()
@@ -252,7 +253,7 @@ func TestAnnualBilling(t *testing.T) {
 		mockWorkspace.EXPECT().GetWorkspaceFromDB(mock.Anything).Return(testWorkspace, nil)
 		mockWorkspace.EXPECT().GetUserFromDB(mock.Anything).Return(testUser, nil)
 
-		mockPayment.EXPECT().ChargeCustomer(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("unable to charge customer"))
+		mockPayment.EXPECT().ChargeCustomer(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return((*billing.ChargeResult)(nil), errors.New("unable to charge customer"))
 		mockPayment.EXPECT().GetServicePlans().Return(testAnnualServicePlans(), nil)
 
 		db, mockSql, err := sqlmock.New()
@@ -321,7 +322,7 @@ func TestAnnualBilling(t *testing.T) {
 		mockWorkspace.EXPECT().GetWorkspaceFromDB(mock.Anything).Return(testWorkspace, nil)
 		mockWorkspace.EXPECT().GetUserFromDB(mock.Anything).Return(testUser, nil)
 
-		mockPayment.EXPECT().ChargeCustomer(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		mockPayment.EXPECT().ChargeCustomer(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&billing.ChargeResult{}, nil)
 		mockPayment.EXPECT().GetServicePlans().Return(testAnnualServicePlans(), nil)
 
 		db, mockSql, err := sqlmock.New()

--- a/cmd/background_emails.go
+++ b/cmd/background_emails.go
@@ -262,7 +262,7 @@ func SendBackgroundEmails() error {
 			}
 			amount := math.Round(float64(balance) * percentOfTrigger)
 
-			if billingInfo.RemainingBalanceCents <= amount {
+			if float64(billingInfo.RemainingBalanceCents) <= amount {
 				args := make(map[string]string)
 				args["triggerPercent"] = fmt.Sprintf("%f", percentOfTrigger)
 				args["triggerBalance"] = fmt.Sprintf("%d", balance)

--- a/cmd/monthly_billing.go
+++ b/cmd/monthly_billing.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -35,12 +34,12 @@ type BillingMetrics struct {
 }
 
 type BillingContext struct {
-	WorkspaceID    int
-	UserID         int
-	StartTime      time.Time
-	EndTime        time.Time
-	CorrelationID  string
-	Logger         *logrus.Entry
+	WorkspaceID   int
+	UserID        int
+	StartTime     time.Time
+	EndTime       time.Time
+	CorrelationID string
+	Logger        *logrus.Entry
 }
 
 func NewMonthlyBillingJob(db *sql.DB, workspaceRepository repository.WorkspaceRepository, paymentRepository repository.PaymentRepository) *MonthlyBillingJob {
@@ -263,15 +262,16 @@ func (mb *MonthlyBillingJob) MonthlyBilling() error {
 		// try to charge the debit
 		if plan.PayAsYouGo {
 			remainingBalance := billingInfo.RemainingBalanceCents
-			minRemaining := remainingBalance - totalCosts
-			charge, err := utils.ComputeAmountToCharge(totalCosts, remainingBalance, minRemaining)
+			remainingBalanceFloat := float64(remainingBalance)
+			minRemaining := remainingBalanceFloat - totalCosts
+			charge, err := utils.ComputeAmountToCharge(totalCosts, remainingBalanceFloat, minRemaining)
 			if err != nil {
 				helpers.Log(logrus.ErrorLevel, "error calculating charge amount\r\n")
 				helpers.Log(logrus.ErrorLevel, err.Error())
 
 				continue
 			}
-			if remainingBalance >= totalCosts { //user has enough credits
+			if remainingBalanceFloat >= totalCosts { //user has enough credits
 				helpers.Log(logrus.InfoLevel, "User has enough credits. Charging balance\r\n")
 
 				confNumber, err := utils.CreateInvoiceConfirmationNumber()
@@ -313,7 +313,7 @@ func (mb *MonthlyBillingJob) MonthlyBilling() error {
 					Id:          int(invoiceId),
 					Cents:       cents,
 					InvoiceDesc: invoiceDesc}
-				err = mb.paymentRepository.ChargeCustomer(billingParams, user, workspace, &invoice)
+				_, err = mb.paymentRepository.ChargeCustomer(billingParams, user, workspace, &invoice)
 				if err != nil {
 					// could not charge card.
 					// update invoice record and mark as outstanding
@@ -350,7 +350,7 @@ func (mb *MonthlyBillingJob) MonthlyBilling() error {
 				Id:          int(invoiceId),
 				Cents:       cents,
 				InvoiceDesc: invoiceDesc}
-			err := mb.paymentRepository.ChargeCustomer(billingParams, user, workspace, &invoice)
+			_, err = mb.paymentRepository.ChargeCustomer(billingParams, user, workspace, &invoice)
 			if err != nil {
 				helpers.Log(logrus.ErrorLevel, "error charging user..\r\n")
 				helpers.Log(logrus.ErrorLevel, err.Error())

--- a/cmd/monthly_billing_test.go
+++ b/cmd/monthly_billing_test.go
@@ -11,6 +11,7 @@ import (
 	helpers "github.com/Lineblocs/go-helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	billing "lineblocs.com/scheduler/handlers/billing"
 	"lineblocs.com/scheduler/mocks"
 )
 
@@ -34,7 +35,7 @@ func testMonthlyServicePlans() []helpers.ServicePlan {
 			MinutesPerMonth:          200.0,
 			BaseCosts:                24.99,
 			ImIntegrations:           true,
-			Name:                     "starter",
+			KeyName:                  "starter",
 			ProductivityIntegrations: true,
 			RecordingSpace:           1024.0,
 		},
@@ -42,7 +43,7 @@ func testMonthlyServicePlans() []helpers.ServicePlan {
 			MinutesPerMonth:          200.0,
 			BaseCosts:                49.99,
 			ImIntegrations:           true,
-			Name:                     "pro",
+			KeyName:                  "pro",
 			ProductivityIntegrations: true,
 			RecordingSpace:           1024.0,
 		},
@@ -112,7 +113,7 @@ func TestMonthlyBilling(t *testing.T) {
 		mockWorkspace.EXPECT().GetWorkspaceBillingInfo(mock.Anything).Return(testBillingInfo, nil)
 		mockWorkspace.EXPECT().GetUserFromDB(mock.Anything).Return(nil, errors.New("failed to get user"))
 
-		mockPayment.EXPECT().ChargeCustomer(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		mockPayment.EXPECT().ChargeCustomer(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&billing.ChargeResult{}, nil)
 		mockPayment.EXPECT().GetServicePlans().Return(testMonthlyServicePlans(), nil)
 
 		db, mockSql, err := sqlmock.New()
@@ -161,7 +162,7 @@ func TestMonthlyBilling(t *testing.T) {
 		mockWorkspace.EXPECT().GetUserFromDB(mock.Anything).Return(testUser, nil)
 		mockWorkspace.EXPECT().GetDIDFromDB(mock.Anything).Return(did, nil)
 
-		mockPayment.EXPECT().ChargeCustomer(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		mockPayment.EXPECT().ChargeCustomer(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&billing.ChargeResult{}, nil)
 		mockPayment.EXPECT().GetServicePlans().Return(testMonthlyServicePlans(), nil)
 
 		db, mockSql, err := sqlmock.New()
@@ -189,7 +190,7 @@ func TestMonthlyBilling(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows([]string{"id", "monthly_cost"}).
 				AddRow(moduleId, monthlyCost))
 
-		debitQuery := "INSERT INTO users_debits (`source`, `status`, `cents`, `module_id`, `user_id`, `workspace_id`, `created_at`) VALUES ( ?, ?, ?, ?, ?, ?)"
+		debitQuery := "INSERT INTO users_debits (`source`, `status`, `cents`, `module_id`, `user_id`, `workspace_id`, `created_at`) VALUES (?, ?, ?, ?, ?, ?, ?)"
 		mockSql.ExpectPrepare(regexp.QuoteMeta(debitQuery)).
 			ExpectExec().
 			WithArgs("NUMBER_RENTAL", "INCOMPLETE", monthlyCost, moduleId, testUser.Id, testWorkspace.Id, sqlmock.AnyArg()).
@@ -267,7 +268,7 @@ func TestMonthlyBilling(t *testing.T) {
 		mockWorkspace.EXPECT().GetUserFromDB(mock.Anything).Return(testUser, nil)
 		mockWorkspace.EXPECT().GetCallFromDB(mock.Anything).Return(call, nil)
 
-		mockPayment.EXPECT().ChargeCustomer(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		mockPayment.EXPECT().ChargeCustomer(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&billing.ChargeResult{}, nil)
 		mockPayment.EXPECT().GetServicePlans().Return(testMonthlyServicePlans(), nil)
 
 		db, mockSql, err := sqlmock.New()
@@ -295,7 +296,7 @@ func TestMonthlyBilling(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows([]string{"id", "monthly_cost"}).
 				AddRow(moduleId, monthlyCost))
 
-		debitQuery := "INSERT INTO users_debits (`source`, `status`, `cents`, `module_id`, `user_id`, `workspace_id`, `created_at`) VALUES ( ?, ?, ?, ?, ?, ?)"
+		debitQuery := "INSERT INTO users_debits (`source`, `status`, `cents`, `module_id`, `user_id`, `workspace_id`, `created_at`) VALUES (?, ?, ?, ?, ?, ?, ?)"
 		mockSql.ExpectPrepare(regexp.QuoteMeta(debitQuery)).
 			ExpectExec().
 			WithArgs("NUMBER_RENTAL", "INCOMPLETE", monthlyCost, moduleId, testUser.Id, testWorkspace.Id, sqlmock.AnyArg()).
@@ -440,7 +441,7 @@ func testMonthlyBillingSetup(mockSql sqlmock.Sqlmock, mockWorkspace *mocks.Works
 
 	mockPayment.EXPECT().GetServicePlans().Return(testMonthlyServicePlans(), nil)
 
-	mockPayment.EXPECT().ChargeCustomer(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockPayment.EXPECT().ChargeCustomer(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&billing.ChargeResult{}, nil)
 
 	mockSql.ExpectQuery("SELECT payment_gateway FROM customizations").
 		WillReturnRows(sqlmock.NewRows([]string{"payment_gateway"}).
@@ -460,7 +461,7 @@ func testMonthlyBillingSetup(mockSql sqlmock.Sqlmock, mockWorkspace *mocks.Works
 		WillReturnRows(sqlmock.NewRows([]string{"id", "monthly_cost"}).
 			AddRow(sampleData.ModuleId, sampleData.Cents))
 
-	debitQuery := "INSERT INTO users_debits (`source`, `status`, `cents`, `module_id`, `user_id`, `workspace_id`, `created_at`) VALUES ( ?, ?, ?, ?, ?, ?)"
+	debitQuery := "INSERT INTO users_debits (`source`, `status`, `cents`, `module_id`, `user_id`, `workspace_id`, `created_at`) VALUES (?, ?, ?, ?, ?, ?, ?)"
 	mockSql.ExpectPrepare(regexp.QuoteMeta(debitQuery)).
 		ExpectExec().
 		WithArgs("NUMBER_RENTAL", "INCOMPLETE", sampleData.Cents, sampleData.ModuleId, sampleData.User.Id, sampleData.Workspace.Id, sqlmock.AnyArg()).

--- a/cmd/worker-billing/main.go
+++ b/cmd/worker-billing/main.go
@@ -69,7 +69,11 @@ func main() {
 
 	for d := range msgs {
 		var task models.BillingTask
-		json.Unmarshal(d.Body, &task)
+		if err := json.Unmarshal(d.Body, &task); err != nil {
+			log.Printf("Invalid billing task payload: %v", err)
+			d.Ack(false) // Drop malformed messages
+			continue
+		}
 
 		err := billingSvc.ProcessTask(task)
 		if err != nil {

--- a/cmd/worker-recordings/main.go
+++ b/cmd/worker-recordings/main.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"encoding/json"
-	"log"
-	"os"
+	amqp "github.com/rabbitmq/amqp091-go"
 	"lineblocs.com/scheduler/internal/storage"
 	"lineblocs.com/scheduler/models"
 	"lineblocs.com/scheduler/utils"
-	amqp "github.com/rabbitmq/amqp091-go"
+	"log"
+	"os"
 )
 
 const (
@@ -30,14 +30,17 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	
+
 	// Ensure queue exists
 	q, err := ch.QueueDeclare(queueName, true, false, false, false, nil)
 	if err != nil {
 		panic(err)
 	}
 
-	msgs, _ := ch.Consume(q.Name, "", false, false, false, false, nil)
+	msgs, err := ch.Consume(q.Name, "", false, false, false, false, nil)
+	if err != nil {
+		panic(err)
+	}
 
 	log.Println("S3 Recording Worker Started...")
 

--- a/internal/storage/service.go
+++ b/internal/storage/service.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
-	"lineblocs.com/scheduler/models"
+	"github.com/CyCoreSystems/ari/v5"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
-	"github.com/CyCoreSystems/ari/v5"
+	"lineblocs.com/scheduler/models"
 )
 
 type RecordingService struct {
@@ -27,10 +27,10 @@ func NewRecordingService(db *sql.DB, ari *ari.Client, settings *models.Settings)
 }
 
 func (s *RecordingService) ProcessRecording(task models.RecordingTask) error {
-	fmt.Printf("Processing Recording ID: %d, StorageID: %d\n", task.ID, task.StorageID)
+	fmt.Printf("Processing Recording ID: %d, StorageID: %s\n", task.ID, task.StorageID)
 
 	// 1. Get File from ARI
-	src := ari.NewKey(ari.StoredRecordingKey, fmt.Sprintf("%d", task.StorageID))
+	src := ari.NewKey(ari.StoredRecordingKey, fmt.Sprintf("%s", task.StorageID))
 	data, err := (*s.ariClient).StoredRecording().File(src)
 	if err != nil {
 		s.db.Exec("UPDATE recordings SET relocation_attempts = relocation_attempts + 1 WHERE id = ?", task.ID)
@@ -43,7 +43,7 @@ func (s *RecordingService) ProcessRecording(task models.RecordingTask) error {
 	}
 
 	// 3. Upload to S3
-	filename := fmt.Sprintf("%d.wav", task.StorageID)
+	filename := fmt.Sprintf("%s.wav", task.StorageID)
 	s3Url, err := s.uploadToS3(data, filename)
 	if err != nil {
 		return err

--- a/mocks/PaymentRepository.go
+++ b/mocks/PaymentRepository.go
@@ -6,6 +6,7 @@ import (
 	lineblocs "github.com/Lineblocs/go-helpers"
 	mock "github.com/stretchr/testify/mock"
 
+	billing "lineblocs.com/scheduler/handlers/billing"
 	models "lineblocs.com/scheduler/models"
 
 	utils "lineblocs.com/scheduler/utils"
@@ -25,21 +26,33 @@ func (_m *PaymentRepository) EXPECT() *PaymentRepository_Expecter {
 }
 
 // ChargeCustomer provides a mock function with given fields: billingParams, user, workspace, invoice
-func (_m *PaymentRepository) ChargeCustomer(billingParams *utils.BillingParams, user *lineblocs.User, workspace *lineblocs.Workspace, invoice *models.UserInvoice) error {
+func (_m *PaymentRepository) ChargeCustomer(billingParams *utils.BillingParams, user *lineblocs.User, workspace *lineblocs.Workspace, invoice *models.UserInvoice) (*billing.ChargeResult, error) {
 	ret := _m.Called(billingParams, user, workspace, invoice)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ChargeCustomer")
 	}
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*utils.BillingParams, *lineblocs.User, *lineblocs.Workspace, *models.UserInvoice) error); ok {
+	var r0 *billing.ChargeResult
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*utils.BillingParams, *lineblocs.User, *lineblocs.Workspace, *models.UserInvoice) (*billing.ChargeResult, error)); ok {
+		return rf(billingParams, user, workspace, invoice)
+	}
+	if rf, ok := ret.Get(0).(func(*utils.BillingParams, *lineblocs.User, *lineblocs.Workspace, *models.UserInvoice) *billing.ChargeResult); ok {
 		r0 = rf(billingParams, user, workspace, invoice)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*billing.ChargeResult)
+		}
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(*utils.BillingParams, *lineblocs.User, *lineblocs.Workspace, *models.UserInvoice) error); ok {
+		r1 = rf(billingParams, user, workspace, invoice)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // PaymentRepository_ChargeCustomer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ChargeCustomer'
@@ -63,12 +76,70 @@ func (_c *PaymentRepository_ChargeCustomer_Call) Run(run func(billingParams *uti
 	return _c
 }
 
-func (_c *PaymentRepository_ChargeCustomer_Call) Return(_a0 error) *PaymentRepository_ChargeCustomer_Call {
-	_c.Call.Return(_a0)
+func (_c *PaymentRepository_ChargeCustomer_Call) Return(_a0 *billing.ChargeResult, _a1 error) *PaymentRepository_ChargeCustomer_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *PaymentRepository_ChargeCustomer_Call) RunAndReturn(run func(*utils.BillingParams, *lineblocs.User, *lineblocs.Workspace, *models.UserInvoice) error) *PaymentRepository_ChargeCustomer_Call {
+func (_c *PaymentRepository_ChargeCustomer_Call) RunAndReturn(run func(*utils.BillingParams, *lineblocs.User, *lineblocs.Workspace, *models.UserInvoice) (*billing.ChargeResult, error)) *PaymentRepository_ChargeCustomer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetSubscription provides a mock function with given fields: subId
+func (_m *PaymentRepository) GetSubscription(subId int) (*lineblocs.Subscription, error) {
+	ret := _m.Called(subId)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetSubscription")
+	}
+
+	var r0 *lineblocs.Subscription
+	var r1 error
+	if rf, ok := ret.Get(0).(func(int) (*lineblocs.Subscription, error)); ok {
+		return rf(subId)
+	}
+	if rf, ok := ret.Get(0).(func(int) *lineblocs.Subscription); ok {
+		r0 = rf(subId)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*lineblocs.Subscription)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(int) error); ok {
+		r1 = rf(subId)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// PaymentRepository_GetSubscription_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetSubscription'
+type PaymentRepository_GetSubscription_Call struct {
+	*mock.Call
+}
+
+// GetSubscription is a helper method to define mock.On call
+//   - subId int
+func (_e *PaymentRepository_Expecter) GetSubscription(subId interface{}) *PaymentRepository_GetSubscription_Call {
+	return &PaymentRepository_GetSubscription_Call{Call: _e.mock.On("GetSubscription", subId)}
+}
+
+func (_c *PaymentRepository_GetSubscription_Call) Run(run func(subId int)) *PaymentRepository_GetSubscription_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(int))
+	})
+	return _c
+}
+
+func (_c *PaymentRepository_GetSubscription_Call) Return(_a0 *lineblocs.Subscription, _a1 error) *PaymentRepository_GetSubscription_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *PaymentRepository_GetSubscription_Call) RunAndReturn(run func(int) (*lineblocs.Subscription, error)) *PaymentRepository_GetSubscription_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,305 +1,310 @@
 package utils
 
 import (
-    "bytes"
-    "crypto/rand"
-    "database/sql"
-    "encoding/json"
-    "fmt"
-    "io"
-    "net/http"
-    "os"
-    "strconv"
-    "time"
-    "math"
+	"bytes"
+	"crypto/rand"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
 
-    helpers "github.com/Lineblocs/go-helpers"
-    _ "github.com/go-sql-driver/mysql"
-    "github.com/joho/godotenv"
-    _ "github.com/mailgun/mailgun-go/v4"
-    "github.com/sirupsen/logrus"
-    "github.com/CyCoreSystems/ari/v5"
-    "github.com/CyCoreSystems/ari/v5/client/native"
-    billing "lineblocs.com/scheduler/handlers/billing"
-    models "lineblocs.com/scheduler/models"
+	"github.com/CyCoreSystems/ari/v5"
+	"github.com/CyCoreSystems/ari/v5/client/native"
+	helpers "github.com/Lineblocs/go-helpers"
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/joho/godotenv"
+	_ "github.com/mailgun/mailgun-go/v4"
+	"github.com/sirupsen/logrus"
+	billing "lineblocs.com/scheduler/handlers/billing"
+	models "lineblocs.com/scheduler/models"
 )
 
 var db *sql.DB
 
 type DBConn struct {
-    Conn *sql.DB
+	Conn *sql.DB
 }
 
 type BillingParams struct {
-    Data     map[string]string
-    Provider string
+	Data     map[string]string
+	Provider string
 }
 
 func NewDBConn(db *sql.DB) *DBConn {
-    if db == nil {
-        db, _ = helpers.CreateDBConn()
-    }
-    return &DBConn{
-        Conn: db,
-    }
+	if db == nil {
+		db, _ = helpers.CreateDBConn()
+	}
+	return &DBConn{
+		Conn: db,
+	}
 }
 
 func GetDBConnection() (*sql.DB, error) {
-    if db != nil {
-        return db, nil
-    }
-    var err error
-    db, err = helpers.CreateDBConn()
-    if err != nil {
-        return nil, err
-    }
-    return db, nil
+	if db != nil {
+		return db, nil
+	}
+	var err error
+	db, err = helpers.CreateDBConn()
+	if err != nil {
+		return nil, err
+	}
+	return db, nil
 }
 
 // GetSettingsFromAPI fetches global credentials and bucket info from the internal API
 func GetSettingsFromAPI() (*models.Settings, error) {
-    apiUrl := os.Getenv("API_URL") + "/user/getSettings"
-    apiKey := os.Getenv("LINEBLOCS_KEY")
+	apiUrl := os.Getenv("API_URL") + "/user/getSettings"
+	apiKey := os.Getenv("LINEBLOCS_KEY")
 
-    req, err := http.NewRequest("GET", apiUrl, nil)
-    if err != nil {
-        return nil, err
-    }
+	req, err := http.NewRequest("GET", apiUrl, nil)
+	if err != nil {
+		return nil, err
+	}
 
-    req.Header.Set("X-Lineblocs-Api-Token", apiKey)
-    req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Lineblocs-Api-Token", apiKey)
+	req.Header.Set("Content-Type", "application/json")
 
-    client := &http.Client{}
-    resp, err := client.Do(req)
-    if err != nil {
-        return nil, err
-    }
-    defer resp.Body.Close()
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
 
-    if resp.StatusCode != http.StatusOK {
-        return nil, fmt.Errorf("API returned status: %d", resp.StatusCode)
-    }
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API returned status: %d", resp.StatusCode)
+	}
 
-    body, err := io.ReadAll(resp.Body)
-    if err != nil {
-        return nil, err
-    }
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
 
-    var settings models.Settings
-    if err := json.Unmarshal(body, &settings); err != nil {
-        return nil, err
-    }
+	var settings models.Settings
+	if err := json.Unmarshal(body, &settings); err != nil {
+		return nil, err
+	}
 
-    return &settings, nil
+	return &settings, nil
 }
 
 // CreateARIConnection initializes a connection to the Asterisk ARI server
 func CreateARIConnection() (*ari.Client, error) {
-    fmt.Println("Connecting to ARI: " + os.Getenv("ARI_URL"))
-    
-    cl, err := native.Connect(&native.Options{
-        Application:  os.Getenv("ARI_RECORDING_APP"),
-        Username:     os.Getenv("ARI_USERNAME"),
-        Password:     os.Getenv("ARI_PASSWORD"),
-        URL:          os.Getenv("ARI_URL"),
-        WebsocketURL: os.Getenv("ARI_WSURL"),
-    })
+	fmt.Println("Connecting to ARI: " + os.Getenv("ARI_URL"))
 
-    if err != nil {
-        fmt.Println("Failed to build native ARI client", "error", err)
-        return nil, err
-    }
+	cl, err := native.Connect(&native.Options{
+		Application:  os.Getenv("ARI_RECORDING_APP"),
+		Username:     os.Getenv("ARI_USERNAME"),
+		Password:     os.Getenv("ARI_PASSWORD"),
+		URL:          os.Getenv("ARI_URL"),
+		WebsocketURL: os.Getenv("ARI_WSURL"),
+	})
 
-    fmt.Println("Connected to ARI server successfully.")
-    return &cl, nil
+	if err != nil {
+		fmt.Println("Failed to build native ARI client", "error", err)
+		return nil, err
+	}
+
+	fmt.Println("Connected to ARI server successfully.")
+	return &cl, nil
 }
 
 func ChargeCustomer(dbConn *sql.DB, billingParams *BillingParams, user *helpers.User, workspace *helpers.Workspace, invoice *models.UserInvoice) error {
-    var hndl billing.BillingHandler
-    retryAttempts, err := strconv.Atoi(billingParams.Data["retry_attempts"])
-    if err != nil {
-        helpers.Log(logrus.InfoLevel, fmt.Sprintf("variable retryAttempts is setup incorrectly. retryAttempts=%s setting value to 0", billingParams.Data["retry_attempts"]))
-        retryAttempts = 0
-    }
+	var hndl billing.BillingHandler
+	retryAttempts, err := strconv.Atoi(billingParams.Data["retry_attempts"])
+	if err != nil {
+		helpers.Log(logrus.InfoLevel, fmt.Sprintf("variable retryAttempts is setup incorrectly. retryAttempts=%s setting value to 0", billingParams.Data["retry_attempts"]))
+		retryAttempts = 0
+	}
 
-    switch billingParams.Provider {
-    case "stripe":
-        key := billingParams.Data["stripe_key"]
-        hndl = billing.NewStripeBillingHandler(dbConn, key, retryAttempts)
-        _, err = hndl.ChargeCustomer(user, workspace, invoice)
-    case "braintree":
-        key := billingParams.Data["braintree_api_key"]
-        hndl = billing.NewBraintreeBillingHandler(dbConn, key, retryAttempts)
-        _, err = hndl.ChargeCustomer(user, workspace, invoice)
-    }
+	switch billingParams.Provider {
+	case "stripe":
+		key := billingParams.Data["stripe_key"]
+		hndl = billing.NewStripeBillingHandler(dbConn, key, retryAttempts)
+		_, err = hndl.ChargeCustomer(user, workspace, invoice)
+	case "braintree":
+		key := billingParams.Data["braintree_api_key"]
+		hndl = billing.NewBraintreeBillingHandler(dbConn, key, retryAttempts)
+		_, err = hndl.ChargeCustomer(user, workspace, invoice)
+	}
 
-    return err
+	return err
 }
 
 func GetRowCount(rows *sql.Rows) (int, error) {
-    var count int
-    for rows.Next() {
-        err := rows.Scan(&count)
-        if err != nil {
-            return 0, err
-        }
-    }
-    return count, nil
+	var count int
+	for rows.Next() {
+		err := rows.Scan(&count)
+		if err != nil {
+			return 0, err
+		}
+	}
+	return count, nil
 }
 
 func DispatchEmail(subject string, emailType string, user *helpers.User, workspace *helpers.Workspace, emailArgs map[string]string) error {
-    url := "http://com/api/sendEmail"
-    to := user.Email
-    email := models.Email{User: *user, Workspace: *workspace, Subject: subject, To: to, EmailType: emailType, Args: emailArgs}
-    b, err := json.Marshal(email)
-    if err != nil {
-        return err
-    }
-    req, _ := http.NewRequest("POST", url, bytes.NewBuffer(b))
-    req.Header.Set("X-Lineblocs-Key", "xxx")
-    req.Header.Set("Content-Type", "application/json")
+	url := "http://com/api/sendEmail"
+	to := user.Email
+	email := models.Email{User: *user, Workspace: *workspace, Subject: subject, To: to, EmailType: emailType, Args: emailArgs}
+	b, err := json.Marshal(email)
+	if err != nil {
+		return err
+	}
+	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(b))
+	req.Header.Set("X-Lineblocs-Key", "xxx")
+	req.Header.Set("Content-Type", "application/json")
 
-    client := &http.Client{}
-    resp, err := client.Do(req)
-    if err != nil {
-        return err
-    }
-    defer resp.Body.Close()
-    return nil
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
 }
 
 func GetPlan(plans []helpers.ServicePlan, workspace *helpers.Workspace) *helpers.ServicePlan {
-    for _, target := range plans {
-        if target.KeyName == workspace.Plan {
-            return &target
-        }
-    }
-    return nil
+	for _, target := range plans {
+		if target.KeyName == workspace.Plan {
+			return &target
+		}
+	}
+	return nil
 }
 
 func GetPlanBySubscription(plans []helpers.ServicePlan, subscription *helpers.Subscription) *helpers.ServicePlan {
-    for _, target := range plans {
-        if target.Id == subscription.CurrentPlanId {
-            return &target
-        }
-    }
-    return nil
+	for _, target := range plans {
+		if target.Id == subscription.CurrentPlanId {
+			return &target
+		}
+	}
+	return nil
 }
 
 func (c *DBConn) GetBillingParams() (*BillingParams, error) {
-    row := c.Conn.QueryRow("SELECT payment_gateway FROM customizations")
-    var paymentGateway string
-    if err := row.Scan(&paymentGateway); err != nil {
-        return nil, err
-    }
+	row := c.Conn.QueryRow("SELECT payment_gateway FROM customizations")
+	var paymentGateway string
+	if err := row.Scan(&paymentGateway); err != nil {
+		return nil, err
+	}
 
-    row = c.Conn.QueryRow("SELECT stripe_private_key FROM api_credentials")
-    var stripePrivateKey string
-    if err := row.Scan(&stripePrivateKey); err != nil {
-        return nil, err
-    }
+	row = c.Conn.QueryRow("SELECT stripe_private_key FROM api_credentials")
+	var stripePrivateKey string
+	if err := row.Scan(&stripePrivateKey); err != nil {
+		return nil, err
+	}
 
-    data := make(map[string]string)
-    data["stripe_key"] = stripePrivateKey
-    data["retry_attempts"] = "0"
-    return &BillingParams{Provider: "stripe", Data: data}, nil
+	data := make(map[string]string)
+	data["stripe_key"] = stripePrivateKey
+	data["retry_attempts"] = "0"
+	return &BillingParams{Provider: "stripe", Data: data}, nil
 }
 
 func Config(key string) string {
-    if os.Getenv("USE_DOTENV") != "off" {
-        _ = godotenv.Load(".env")
-    }
-    return os.Getenv(key)
+	if os.Getenv("USE_DOTENV") != "off" {
+		_ = godotenv.Load(".env")
+	}
+	return os.Getenv(key)
 }
 
 func ComputeAmountToCharge(fullCentsToCharge float64, availMinutes float64, minutes float64) (float64, error) {
-    minAfterDebit := availMinutes - minutes
-    if availMinutes > 0 && minAfterDebit < 0 && availMinutes <= minutes {
-        percentOfDebit, err := strconv.ParseFloat(fmt.Sprintf(".%s", strconv.FormatFloat((minutes-availMinutes), 'f', -1, 64)), 64)
-        if err != nil {
-            return 0, err
-        }
-        centsToCharge := math.Abs(fullCentsToCharge * percentOfDebit)
-        return math.Max(1, centsToCharge), nil
-    } else if availMinutes >= minutes {
-        return 0, nil
-    } else if availMinutes <= 0 {
-        return fullCentsToCharge, nil
-    }
-    return 0, fmt.Errorf("billing error: computeAmountToCharge logic failure")
+	minAfterDebit := availMinutes - minutes
+	if availMinutes > 0 && minAfterDebit < 0 && availMinutes <= minutes {
+		percentOfDebit, err := strconv.ParseFloat(fmt.Sprintf(".%s", strconv.FormatFloat((minutes-availMinutes), 'f', -1, 64)), 64)
+		if err != nil {
+			return 0, err
+		}
+		centsToCharge := math.Abs(fullCentsToCharge * percentOfDebit)
+		return math.Max(1, centsToCharge), nil
+	} else if availMinutes >= minutes {
+		return 0, nil
+	} else if availMinutes <= 0 {
+		return fullCentsToCharge, nil
+	}
+	return 0, fmt.Errorf("billing error: computeAmountToCharge logic failure")
 }
 
 func CreateMonthlyNumberRentalDebit(db *sql.DB, workspaceId int, userId int, start time.Time) (int, int) {
-    var didId int
-    var monthlyCosts int
-    results1, err := db.Query("SELECT id, monthly_cost FROM did_numbers WHERE workspace_id = ?", workspaceId)
-    if err != nil {
-        return 0, 0
-    }
-    defer results1.Close()
-    for results1.Next() {
-        results1.Scan(&didId, &monthlyCosts)
-        stmt, _ := db.Prepare("INSERT INTO users_debits (`source`, `status`, `cents`, `module_id`, `user_id`, `workspace_id`, `created_at`) VALUES (?, ?, ?, ?, ?, ?, ?)")
-        defer stmt.Close()
-        _, _ = stmt.Exec("NUMBER_RENTAL", "INCOMPLETE", monthlyCosts, didId, userId, workspaceId, start)
-    }
-    return didId, monthlyCosts
+	var didId int
+	var monthlyCosts int
+	results1, err := db.Query("SELECT id, monthly_cost FROM did_numbers WHERE workspace_id = ?", workspaceId)
+	if err != nil {
+		return 0, 0
+	}
+	defer results1.Close()
+	for results1.Next() {
+		if err := results1.Scan(&didId, &monthlyCosts); err != nil {
+			continue
+		}
+		stmt, err := db.Prepare("INSERT INTO users_debits (`source`, `status`, `cents`, `module_id`, `user_id`, `workspace_id`, `created_at`) VALUES (?, ?, ?, ?, ?, ?, ?)")
+		if err != nil {
+			continue
+		}
+		_, _ = stmt.Exec("NUMBER_RENTAL", "INCOMPLETE", monthlyCosts, didId, userId, workspaceId, start)
+		_ = stmt.Close()
+	}
+	return didId, monthlyCosts
 }
 
 func GetWorkspaceUserCount(db *sql.DB, workspaceId int) int {
-    rows, err := db.Query("SELECT COUNT(*) as count FROM workspaces_users WHERE workspace_id = ?", workspaceId)
-    if err != nil {
-        return 0
-    }
-    defer rows.Close()
-    userCount, _ := GetRowCount(rows)
-    return userCount
+	rows, err := db.Query("SELECT COUNT(*) as count FROM workspaces_users WHERE workspace_id = ?", workspaceId)
+	if err != nil {
+		return 0
+	}
+	defer rows.Close()
+	userCount, _ := GetRowCount(rows)
+	return userCount
 }
 
 func CreateInvoiceConfirmationNumber() (string, error) {
-    b := make([]byte, 12)
-    if _, err := rand.Read(b); err != nil {
-        return "", err
-    }
-    return fmt.Sprintf("INV-%08X", b[:4]), nil
+	b := make([]byte, 12)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("INV-%08X", b[:4]), nil
 }
 
 func CreateTaxMetadata(callTollsCosts, recordingCosts, faxCosts, membershipCosts, numberRentalCosts int64) string {
-    taxMetadata := map[string]int64{
-        "call_tolls_costs":    callTollsCosts,
-        "recording_costs":     recordingCosts,
-        "fax_costs":           faxCosts,
-        "membership_costs":    membershipCosts,
-        "number_rental_costs": numberRentalCosts,
-    }
-    b, _ := json.Marshal(taxMetadata)
-    return string(b)
+	taxMetadata := map[string]int64{
+		"call_tolls_costs":    callTollsCosts,
+		"recording_costs":     recordingCosts,
+		"fax_costs":           faxCosts,
+		"membership_costs":    membershipCosts,
+		"number_rental_costs": numberRentalCosts,
+	}
+	b, _ := json.Marshal(taxMetadata)
+	return string(b)
 }
 
 func CalculateInitialCharge(price float64, billingType string) (float64, time.Time) {
-    now := time.Now()
-    var nextAnchor time.Time
-    
-    if billingType == "MONTHLY" {
-        // Next 1st of the month
-        nextAnchor = time.Date(now.Year(), now.Month()+1, 1, 0, 0, 0, 0, now.Location())
-    } else if billingType == "ANNUAL" {
-        // Next Jan 1st
-        nextAnchor = time.Date(now.Year()+1, 1, 1, 0, 0, 0, 0, now.Location())
-    }
+	now := time.Now()
+	var nextAnchor time.Time
 
-    // Days in current month or year
-    currentPeriodStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
-    if billingType == "ANNUAL" {
-        currentPeriodStart = time.Date(now.Year(), 1, 1, 0, 0, 0, 0, now.Location())
-    }
+	if billingType == "MONTHLY" {
+		// Next 1st of the month
+		nextAnchor = time.Date(now.Year(), now.Month()+1, 1, 0, 0, 0, 0, now.Location())
+	} else if billingType == "ANNUAL" {
+		// Next Jan 1st
+		nextAnchor = time.Date(now.Year()+1, 1, 1, 0, 0, 0, 0, now.Location())
+	}
 
-    totalDaysInPeriod := nextAnchor.Sub(currentPeriodStart).Hours() / 24
-    daysRemaining := nextAnchor.Sub(now).Hours() / 24
+	// Days in current month or year
+	currentPeriodStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+	if billingType == "ANNUAL" {
+		currentPeriodStart = time.Date(now.Year(), 1, 1, 0, 0, 0, 0, now.Location())
+	}
 
-    // Prorated Amount
-    amount := (price / totalDaysInPeriod) * daysRemaining
-    
-    // Standard rounding for currency
-    return math.Round(amount*100) / 100, nextAnchor
+	totalDaysInPeriod := nextAnchor.Sub(currentPeriodStart).Hours() / 24
+	daysRemaining := nextAnchor.Sub(now).Hours() / 24
+
+	// Prorated Amount
+	amount := (price / totalDaysInPeriod) * daysRemaining
+
+	// Standard rounding for currency
+	return math.Round(amount*100) / 100, nextAnchor
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -21,15 +21,15 @@ func TestGetPlan(t *testing.T) {
 
 		plans := []helpers.ServicePlan{
 			{
-				Name: "starter",
+				KeyName: "starter",
 			},
 			{
-				Name: "premium",
+				KeyName: "premium",
 			},
 		}
 
 		plan := GetPlan(plans, workspace)
-		assert.Equal(t, workspace.Plan, plan.Name)
+		assert.Equal(t, workspace.Plan, plan.KeyName)
 	})
 
 	t.Run("Should return empty plan", func(t *testing.T) {
@@ -41,10 +41,10 @@ func TestGetPlan(t *testing.T) {
 
 		plans := []helpers.ServicePlan{
 			{
-				Name: "starter",
+				KeyName: "starter",
 			},
 			{
-				Name: "premium",
+				KeyName: "premium",
 			},
 		}
 


### PR DESCRIPTION
This pull request refactors the `ChargeCustomer` method in the payment repository to return both a result and an error, and updates all related usages and tests to match the new signature. It also improves type consistency for service plan identifiers and fixes a few minor issues in background jobs and worker code. The most important changes are grouped below:

### Payment Repository API Refactor

* Changed the signature of `ChargeCustomer` in `PaymentRepository` to return `(*billing.ChargeResult, error)` instead of just `error`, updating all usages in billing jobs and tests accordingly. This enables callers to access additional details about the charge operation and improves error handling. 

### Service Plan Key Consistency

* Standardized the identifier for service plans from `Name` to `KeyName` in both annual and monthly billing tests, improving clarity and consistency in plan references.

### Type and Comparison Fixes

* Fixed type mismatches by converting integer values to floats for correct comparisons in background email triggers and monthly billing logic, preventing subtle bugs in payment threshold checks. 
### Worker and Storage Improvements

* Improved error handling in billing and recordings workers by checking for JSON unmarshal errors and AMQP consume errors, logging issues, and dropping malformed messages to avoid crashes.

### Minor Test Query Fixes

* Fixed SQL query formatting in monthly billing tests to match the expected number of parameters, reducing test failures due to query mismatches.